### PR TITLE
Fix `ava` to version ^0.25.0 and update linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - '10'
   - '8'
   - '6'
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,5 @@ language: node_js
 node_js:
   - '8'
   - '6'
-  - '4'
 after_script:
   - npm run coveralls

--- a/fixtures/stub-sns.js
+++ b/fixtures/stub-sns.js
@@ -21,8 +21,8 @@ const stub = sinon.stub(sns, 'publish');
 stub.withArgs({Message: 'foo', TopicArn: 'arn:aws:sns:us-west-2:111122223333:MyTopic'}).yields(undefined, {MessageId: 'foo'});
 stub.withArgs({Message: 'foo', TargetArn: 'arn:aws:sns:us-west-2:111122223333:GCM/MyTopic'}).yields(undefined, {MessageId: 'bar'});
 stub.withArgs({Message: 'foo', TopicArn: 'arn:aws:sns:us-west-2:111122223333:MyTopic', Subject: 'Hello World'}).yields(undefined, {MessageId: 'baz'});
-stub.withArgs({Message: 'foo', PhoneNumber: '+14155552671'}).yields(undefined, {MessageId: 'phone'})
-stub.withArgs({Message: 'foo', TopicArn: 'arn:aws:sns:us-west-2:111122223333:MyTopic', PhoneNumber: '+14155552671'}).yields(undefined, {MessageId: 'phonearn'})
-stub.withArgs({Message: 'foo', TopicArn: 'arn:aws:sns:eu-west-1:123456789012:MyTopic'}).yields(undefined, {MessageId: 'name eu'})
-stub.withArgs({Message: 'foo', TopicArn: 'arn:aws:sns:us-west-2:123456789012:MyTopic'}).yields(undefined, {MessageId: 'name us'})
+stub.withArgs({Message: 'foo', PhoneNumber: '+14155552671'}).yields(undefined, {MessageId: 'phone'});
+stub.withArgs({Message: 'foo', TopicArn: 'arn:aws:sns:us-west-2:111122223333:MyTopic', PhoneNumber: '+14155552671'}).yields(undefined, {MessageId: 'phonearn'});
+stub.withArgs({Message: 'foo', TopicArn: 'arn:aws:sns:eu-west-1:123456789012:MyTopic'}).yields(undefined, {MessageId: 'name eu'});
+stub.withArgs({Message: 'foo', TopicArn: 'arn:aws:sns:us-west-2:123456789012:MyTopic'}).yields(undefined, {MessageId: 'name us'});
 stub.yields(undefined, {MessageId: 'bla'});

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "pify": "^2.3.0"
   },
   "devDependencies": {
-    "ava": "*",
-    "aws-sdk": "^2.2.33",
+    "ava": "^0.25.0",
+    "aws-sdk": "^2.441.0",
     "coveralls": "^2.13.0",
     "nyc": "^10.2.0",
     "sinon": "^1.17.2",


### PR DESCRIPTION
This is kinda a follow up on [this PR](https://github.com/SamVerschueren/aws-sns-publish/pull/4)