### PR TITLE
Add support for message attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const snsPublish = pify(sns.publish.bind(sns));
 
 const isValidTopicName = input => /^[\w-]{1,255}$/.test(input);
 
-const convertObjectToAttributeMap = input => {
+const convertObjectToMessageAttributes = input => {
 	const result = {};
 
 	for (const key of Object.keys(input)) {

--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ const convertObjectToMessageAttributes = input => {
 	const result = {};
 
 	for (const key of Object.keys(input)) {
-		let parsedValue = `${input[key]}`;
+		const value = input[key];
+		let parsedValue = `${value}`;
 		let dataType = 'String';
 
 		if (Array.isArray(value)) {
@@ -83,8 +84,8 @@ module.exports = (message, opts) => {
 		params.Subject = opts.subject;
 	}
 
-	if (opts.messageAttributes) {
-		params.MessageAttributes = convertObjectToAttributeMap(opts.messageAttributes);
+	if (opts.attributes) {
+		params.MessageAttributes = convertObjectToMessageAttributes(opts.attributes);
 	}
 
 	return snsPublish(params).then(data => data.MessageId);

--- a/index.js
+++ b/index.js
@@ -11,28 +11,28 @@ const snsPublish = pify(sns.publish.bind(sns));
 
 const isValidTopicName = input => /^[\w-]{1,255}$/.test(input);
 
-const convertObjectToAttributeMap = input => Object.entries(input).reduce((previous, [key, value]) => {
-	let parsedValue = `${value}`;
-	let dataType = 'String';
+const convertObjectToAttributeMap = input => {
+	const result = {};
 
-	if (Array.isArray(value)) {
-		dataType = 'String.Array';
-		parsedValue = JSON.stringify(value);
-	} else if (typeof value === 'number') {
-		dataType = 'Number';
-	}
+	for (const key of Object.keys(input)) {
+		let parsedValue = `${input[key]}`;
+		let dataType = 'String';
 
-	return Object.assign({}, previous, {
-		DataType: dataType,
-		StringValue: parsedValue
-	});
-		...previous,
-		[key]: {
+		if (Array.isArray(value)) {
+			dataType = 'String.Array';
+			parsedValue = JSON.stringify(value);
+		} else if (typeof value === 'number') {
+			dataType = 'Number';
+		}
+
+		result[key] = {
 			DataType: dataType,
 			StringValue: parsedValue
-		}
-	};
-}, {});
+		};
+	}
+
+	return result;
+};
 
 module.exports = (message, opts) => {
 	opts = Object.assign({

--- a/index.js
+++ b/index.js
@@ -22,7 +22,10 @@ const convertObjectToAttributeMap = input => Object.entries(input).reduce((previ
 		dataType = 'Number';
 	}
 
-	return {
+	return Object.assign({}, previous, {
+		DataType: dataType,
+		StringValue: parsedValue
+	});
 		...previous,
 		[key]: {
 			DataType: dataType,

--- a/readme.md
+++ b/readme.md
@@ -106,7 +106,7 @@ Default: `process.env.AWS_ACCOUNT_ID`
 
 AWS Account Id used when constructing the topic ARN when `name` is being used.
 
-#### messageAttributes
+#### attributes
 
 Type: `Object`
 

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,11 @@ snsPublish('SMS Message', {phone: '+14155552671'}).then(messageId => {
 	console.log(messageId);
 	//=> '6014fe16-26c1-11e7-93ae-92361f002671'
 });
+
+snsPublish('Hello World', {arn: 'arn:aws:sns:us-west-2:111122223333:MyTopic', messageAttributes: {hello: 'world'}}).then(messageId => {
+	console.log(messageId);
+	//=> 'ef5835d5-8a4b-4e8b-beff-6ccc314d2f6d'
+});
 ```
 
 
@@ -101,6 +106,11 @@ Default: `process.env.AWS_ACCOUNT_ID`
 
 AWS Account Id used when constructing the topic ARN when `name` is being used.
 
+#### messageAttributes
+
+Type: `object`
+
+Object which defines the message attributes to be set.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -108,7 +108,7 @@ AWS Account Id used when constructing the topic ARN when `name` is being used.
 
 #### messageAttributes
 
-Type: `object`
+Type: `Object`
 
 Object which defines the message attributes to be set.
 

--- a/readme.md
+++ b/readme.md
@@ -110,7 +110,7 @@ AWS Account Id used when constructing the topic ARN when `name` is being used.
 
 Type: `Object`
 
-Object which defines the message attributes to be set.
+Key-value map defining the message attributes of the SNS message.
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -81,7 +81,7 @@ test.serial('phone, topic and subject', async t => {
 });
 
 test.serial('message attributes - string', async t => {
-	await m(JSON.stringify({foo: 'foo'}), {arn: 'arn:aws:sns:us-west-2:111122223333:MyTopic', json: true, messageAttributes: {bar: 'bar'}});
+	await m(JSON.stringify({foo: 'foo'}), {arn: 'arn:aws:sns:us-west-2:111122223333:MyTopic', json: true, attributes: {bar: 'bar'}});
 
 	t.deepEqual(sns.publish.lastCall.args[0], {
 		Message: '{"foo":"foo"}',
@@ -96,7 +96,7 @@ test.serial('message attributes - string', async t => {
 });
 
 test.serial('message attributes - string array', async t => {
-	await m(JSON.stringify({foo: 'bar'}), {arn: 'arn:aws:sns:us-west-2:111122223333:MyTopic', json: true, messageAttributes: {bar: ['bar']}});
+	await m(JSON.stringify({foo: 'bar'}), {arn: 'arn:aws:sns:us-west-2:111122223333:MyTopic', json: true, attributes: {bar: ['bar']}});
 
 	t.deepEqual(sns.publish.lastCall.args[0], {
 		Message: '{"foo":"bar"}',
@@ -111,7 +111,7 @@ test.serial('message attributes - string array', async t => {
 });
 
 test.serial('message attributes - number', async t => {
-	await m(JSON.stringify({foo: 'bar'}), {arn: 'arn:aws:sns:us-west-2:111122223333:MyTopic', json: true, messageAttributes: {bar: 0}});
+	await m(JSON.stringify({foo: 'bar'}), {arn: 'arn:aws:sns:us-west-2:111122223333:MyTopic', json: true, attributes: {bar: 0}});
 
 	t.deepEqual(sns.publish.lastCall.args[0], {
 		Message: '{"foo":"bar"}',
@@ -126,7 +126,7 @@ test.serial('message attributes - number', async t => {
 });
 
 test.serial('message attributes - number array', async t => {
-	await m(JSON.stringify({foo: 'bar'}), {arn: 'arn:aws:sns:us-west-2:111122223333:MyTopic', json: true, messageAttributes: {bar: [0]}});
+	await m(JSON.stringify({foo: 'bar'}), {arn: 'arn:aws:sns:us-west-2:111122223333:MyTopic', json: true, attributes: {bar: [0]}});
 
 	t.deepEqual(sns.publish.lastCall.args[0], {
 		Message: '{"foo":"bar"}',
@@ -141,7 +141,7 @@ test.serial('message attributes - number array', async t => {
 });
 
 test.serial('message attributes - boolean', async t => {
-	await m(JSON.stringify({foo: 'bar'}), {arn: 'arn:aws:sns:us-west-2:111122223333:MyTopic', json: true, messageAttributes: {bar: true}});
+	await m(JSON.stringify({foo: 'bar'}), {arn: 'arn:aws:sns:us-west-2:111122223333:MyTopic', json: true, attributes: {bar: true}});
 
 	t.deepEqual(sns.publish.lastCall.args[0], {
 		Message: '{"foo":"bar"}',
@@ -156,7 +156,7 @@ test.serial('message attributes - boolean', async t => {
 });
 
 test.serial('message attributes - boolean array', async t => {
-	await m(JSON.stringify({foo: 'bar'}), {arn: 'arn:aws:sns:us-west-2:111122223333:MyTopic', json: true, messageAttributes: {bar: [true]}});
+	await m(JSON.stringify({foo: 'bar'}), {arn: 'arn:aws:sns:us-west-2:111122223333:MyTopic', json: true, attributes: {bar: [true]}});
 
 	t.deepEqual(sns.publish.lastCall.args[0], {
 		Message: '{"foo":"bar"}',

--- a/test.js
+++ b/test.js
@@ -79,3 +79,93 @@ test.serial('phone, topic and subject', async t => {
 		Subject: 'MySubject'
 	});
 });
+
+test.serial('message attributes - string', async t => {
+	await m(JSON.stringify({foo: 'foo'}), {arn: 'arn:aws:sns:us-west-2:111122223333:MyTopic', json: true, messageAttributes: {bar: 'bar'}});
+
+	t.deepEqual(sns.publish.lastCall.args[0], {
+		Message: '{"foo":"foo"}',
+		TopicArn: 'arn:aws:sns:us-west-2:111122223333:MyTopic',
+		MessageAttributes: {
+			bar: {
+				DataType: 'String',
+				StringValue: 'bar'
+			}
+		}
+	});
+});
+
+test.serial('message attributes - string array', async t => {
+	await m(JSON.stringify({foo: 'bar'}), {arn: 'arn:aws:sns:us-west-2:111122223333:MyTopic', json: true, messageAttributes: {bar: ['bar']}});
+
+	t.deepEqual(sns.publish.lastCall.args[0], {
+		Message: '{"foo":"bar"}',
+		TopicArn: 'arn:aws:sns:us-west-2:111122223333:MyTopic',
+		MessageAttributes: {
+			bar: {
+				DataType: 'String.Array',
+				StringValue: '["bar"]'
+			}
+		}
+	});
+});
+
+test.serial('message attributes - number', async t => {
+	await m(JSON.stringify({foo: 'bar'}), {arn: 'arn:aws:sns:us-west-2:111122223333:MyTopic', json: true, messageAttributes: {bar: 0}});
+
+	t.deepEqual(sns.publish.lastCall.args[0], {
+		Message: '{"foo":"bar"}',
+		TopicArn: 'arn:aws:sns:us-west-2:111122223333:MyTopic',
+		MessageAttributes: {
+			bar: {
+				DataType: 'Number',
+				StringValue: '0'
+			}
+		}
+	});
+});
+
+test.serial('message attributes - number array', async t => {
+	await m(JSON.stringify({foo: 'bar'}), {arn: 'arn:aws:sns:us-west-2:111122223333:MyTopic', json: true, messageAttributes: {bar: [0]}});
+
+	t.deepEqual(sns.publish.lastCall.args[0], {
+		Message: '{"foo":"bar"}',
+		TopicArn: 'arn:aws:sns:us-west-2:111122223333:MyTopic',
+		MessageAttributes: {
+			bar: {
+				DataType: 'String.Array',
+				StringValue: '[0]'
+			}
+		}
+	});
+});
+
+test.serial('message attributes - boolean', async t => {
+	await m(JSON.stringify({foo: 'bar'}), {arn: 'arn:aws:sns:us-west-2:111122223333:MyTopic', json: true, messageAttributes: {bar: true}});
+
+	t.deepEqual(sns.publish.lastCall.args[0], {
+		Message: '{"foo":"bar"}',
+		TopicArn: 'arn:aws:sns:us-west-2:111122223333:MyTopic',
+		MessageAttributes: {
+			bar: {
+				DataType: 'String',
+				StringValue: 'true'
+			}
+		}
+	});
+});
+
+test.serial('message attributes - boolean array', async t => {
+	await m(JSON.stringify({foo: 'bar'}), {arn: 'arn:aws:sns:us-west-2:111122223333:MyTopic', json: true, messageAttributes: {bar: [true]}});
+
+	t.deepEqual(sns.publish.lastCall.args[0], {
+		Message: '{"foo":"bar"}',
+		TopicArn: 'arn:aws:sns:us-west-2:111122223333:MyTopic',
+		MessageAttributes: {
+			bar: {
+				DataType: 'String.Array',
+				StringValue: '[true]'
+			}
+		}
+	});
+});


### PR DESCRIPTION
This add support for message attributes.

Implemented according to: 
- https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SNS.html#publish-property
- https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html#SNSMessageAttributes.DataTypes