### PR TITLE
Fix readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ snsPublish('SMS Message', {phone: '+14155552671'}).then(messageId => {
 	//=> '6014fe16-26c1-11e7-93ae-92361f002671'
 });
 
-snsPublish('Hello World', {arn: 'arn:aws:sns:us-west-2:111122223333:MyTopic', messageAttributes: {hello: 'world'}}).then(messageId => {
+snsPublish('Hello World', {arn: 'arn:aws:sns:us-west-2:111122223333:MyTopic', attributes: {hello: 'world'}}).then(messageId => {
 	console.log(messageId);
 	//=> 'ef5835d5-8a4b-4e8b-beff-6ccc314d2f6d'
 });


### PR DESCRIPTION
The example in the readme indicated that `messageAttributes` should be provided while it has to be `attributes`